### PR TITLE
fix the bug when sort reviews

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ router.get('/apps/:appId/reviews', function (req, res, next) {
     return apps;
   }
 
+  req.query.sort = gplay.sort[req.query.sort || 'NEWEST']
   const opts = Object.assign({appId: req.params.appId}, req.query);
   gplay.reviews(opts)
     .then(toList)


### PR DESCRIPTION
There is a bug when get reviews with sort params.
like: `/api/apps/com.elex.lastbattlegroundsurvival/reviews?lang=en&sort=NEWEST`
can not pass sort params to  [google-play-scraper](https://github.com/facundoolano/google-play-scraper)